### PR TITLE
Store edge relations on the nodes rather than in a hashmap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ impl <NodeData : Eq + Hash, EdgeData : Eq + Hash> Dag<NodeData, EdgeData> for On
     }
     fn add_edge(&mut self, from: Self::NodeHandle, to: Self::NodeHandle, data: EdgeData) -> Result<(),()> {
         let to_node = to.node.borrow();
-        if self.is_reachable(&to, &from) {
+        if self.is_reachable(&from, &to) {
             // there is a path from `to` to `from`, so adding an edge `from` -> `to` will introduce
             // a cycle.
             Err(())
@@ -75,9 +75,9 @@ impl <N: Eq, E: Eq + Hash> OnDag<N, E> {
             node.borrow().children.iter()
     }*/
     /// Return true if and only if `search` is reachable from (or is equal to) `base`
-    fn is_reachable(&self, base: &DagNodeHandle<N, E>, search: &DagNodeHandle<N, E>) -> bool {
+    fn is_reachable(&self, search: &DagNodeHandle<N, E>, base: &DagNodeHandle<N, E>) -> bool {
         (base == search) || base.node.borrow().children.iter().any(|ch| {
-            self.is_reachable(&ch.to, search)
+            self.is_reachable(search, &ch.to)
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,200 +1,147 @@
+//#![cfg(unstable)]
+#![feature(conservative_impl_trait)]
 //#[cfg(test)]
 //mod tests;
 //
-use std::collections::{HashMap, HashSet};
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
 
-pub trait Dag<NodeData : Eq, EdgeData : Eq + Hash> {
+pub trait Dag<NodeData : Eq + Hash, EdgeData : Eq + Hash> {
     type NodeHandle;
     fn add_node(&mut self, node: NodeData) -> Self::NodeHandle;
     fn add_edge(&mut self, from: Self::NodeHandle, to: Self::NodeHandle, data: EdgeData) -> Result<(),()>;
     fn del_edge(&mut self, from: Self::NodeHandle, to: Self::NodeHandle, data: EdgeData) -> Result<(),()>;
 }
 
-
-pub struct DagNodeHandle<T> {
-    value : Rc<T>,
+pub struct DagNodeHandle<NodeData, EdgeData> {
+    node: Rc<RefCell<DagNode<NodeData, EdgeData>>>,
 }
 
 #[derive(PartialEq, Eq)]
 struct DagEdge<NodeData, EdgeData> {
-    to: DagNodeHandle<NodeData>,
-    user_data: EdgeData,
+    to: DagNodeHandle<NodeData, EdgeData>,
+    weight: EdgeData,
+}
+
+struct DagNode<NodeData, EdgeData> {
+    value: NodeData,
+    children: HashSet<DagEdge<NodeData, EdgeData>>,
 }
 
 // TODO: use a small-size optimized Set, e.g. smallset
 // https://github.com/cfallin/rust-smallset/blob/master/src/lib.rs
-type DagFwdEdgeMap<NodeData, EdgeData> = HashMap<DagNodeHandle<NodeData>, HashSet<DagEdge<NodeData, EdgeData>>>;
-type DagRevEdgeMap<NodeData> = HashMap<DagNodeHandle<NodeData>, HashSet<DagNodeHandle<NodeData>>>;
-
 
 pub struct OnDag<NodeData, EdgeData> {
-    fwd_edges: DagFwdEdgeMap<NodeData, EdgeData>,
-    rev_edges: DagRevEdgeMap<NodeData>,
-    orphans: HashSet<DagNodeHandle<NodeData>>,
+    // even though the root can't have any parents, we need to keep this as a
+    // DagNodeHandle type for yielding during iteration (etc).
+    root: DagNodeHandle<NodeData, EdgeData>,
 }
 
-impl <NodeData : Eq, EdgeData : Eq + Hash> Dag<NodeData, EdgeData> for OnDag<NodeData, EdgeData> {
-    type NodeHandle = DagNodeHandle<NodeData>;
-    fn add_node(&mut self, node: NodeData) -> Self::NodeHandle {
-        let handle = Self::NodeHandle::new(node);
-        self.orphans.insert(handle.clone());
-        self.fwd_edges.entry(handle.clone()).or_insert_with(HashSet::new);
-        self.rev_edges.entry(handle.clone()).or_insert_with(HashSet::new);
+impl <NodeData : Eq + Hash, EdgeData : Eq + Hash> Dag<NodeData, EdgeData> for OnDag<NodeData, EdgeData> {
+    type NodeHandle = DagNodeHandle<NodeData, EdgeData>;
+    fn add_node(&mut self, node_data: NodeData) -> Self::NodeHandle {
+        let handle = Self::NodeHandle::new(DagNode::new(node_data));
         handle
     }
     fn add_edge(&mut self, from: Self::NodeHandle, to: Self::NodeHandle, data: EdgeData) -> Result<(),()> {
-        // ensure both `from` and `to` exist in this graph:
-        if !(self.fwd_edges.contains_key(&from) && self.fwd_edges.contains_key(&to)) {
+        let to_node = to.node.borrow();
+        /*if to_node.iter_depth_first().any(|node| { node == &from }) {
+            // there is a path from `to` to `from`, so adding an edge `from` -> `to` will introduce
+            // a cycle.
             Err(())
         } else {
-            // if `to` was an orphan, it is no longer.
-            self.orphans.remove(&to);
-
-            // add the child -> parent relationship
-            self.rev_edges.entry(to.clone())
-                .or_insert_with(HashSet::new)
-                .insert(from.clone());
-
-            // add the parent -> child relationship
-            let edge = DagEdge{ to: to, user_data: data };
-            self.fwd_edges.entry(from)
-                .or_insert_with(HashSet::new)
-                .insert(edge);
-
-            self.assert_acyclic()
-        }
+            // add the parent -> child link:
+            from.node.borrow_mut().children.insert(DagEdge::new(to.clone(), data));
+            // add the child -> parent link:
+            to.node.borrow_mut().parents.insert(from.clone());
+            Ok(())
+        }*/
+        Ok(())
     }
     fn del_edge(&mut self, from: Self::NodeHandle, to: Self::NodeHandle, data: EdgeData) -> Result<(), ()> {
-        // delete the child -> parent relationship
-        match self.rev_edges.get_mut(&to) {
-            None => Err(()), // edge was never in the graph
-            Some(mut entry) => {
-                match entry.remove(&from) {
-                    true => {
-                        // If there are no more incoming edges, `to` has been orphaned
-                        if entry.is_empty() {
-                            self.orphans.insert(to.clone());
-                        }
-                        Ok(())
-                    },
-                    false => Err(()), // edge not in graph
-                }
-            }
-        }
-        .and_then(|()| {
-            // delete the parent -> child relationship
-            // it's safe to unwrap this because we never leave asymmetric edges.
-            self.fwd_edges.get_mut(&from).unwrap()
-                .remove(&DagEdge{ to: to, user_data: data});
-            Ok(())
-        })
+        // delete the parent -> child relationship:
+        from.node.borrow_mut().children.remove(&DagEdge::new(to.clone(), data));
+        Ok(())
     }
 }
 
-impl <NodeData : Eq, EdgeData : Eq + Hash> OnDag<NodeData, EdgeData> {
-    pub fn new() -> Self {
+impl <N: Eq, E: Eq + Hash> OnDag<N, E> {
+    /*fn iter_depth_first(&self) -> impl Iterator<Item=DagNodeHandle<NodeData, EdgeData>> {
+        self.root.value.iter_depth_first()
+    }*/
+    /*fn iter_edges<'a>(&'a self, start_edge: &'a DagEdge<N, E>) -> impl Iterator<Item=&'a DagEdge<N, E>> + 'a {
+            let ref node = start_edge.to.node;
+            node.borrow().children.iter()
+    }*/
+}
+
+impl <NodeData : Eq + Hash, EdgeData : Eq + Hash> OnDag<NodeData, EdgeData> {
+    pub fn new(node_data: NodeData) -> Self {
         OnDag {
-            fwd_edges: DagFwdEdgeMap::new(),
-            rev_edges: DagRevEdgeMap::new(),
-            orphans: HashSet::new(),
+            root: DagNodeHandle::new(DagNode::new(node_data)),
         }
     }
-    /*
-    /// get a copy of the edges, but avoid cloning any user-provided values, by using refs.
-    /// Also, omit the edge data.
-    fn clone_edges_ref(&self) -> DagnweightedEdgeMap<NodeData> {
-        let mut r = DagUnweightedEdgeMap::new();
-        for (ref node, ref edge_set) in self.edges.iter() {
-            let mut unweighted_edges = HashSet::new();
-            for edge in edge_set.iter() {
-                unweighted_edges.insert(edge.to.clone());
-            }
-            // TODO: why can't we use node.clone() instead of manually filling DagNodeHandle?
-            r.insert(DagNodeHandle{ value: node.value.clone() }, unweighted_edges);
-        }
-        r
-    }
-    */
-    fn assert_acyclic(&self) -> Result<(), ()> {
-        // Kahn's algorithm:
-        // init `orphans` to the set of all nodes with no parents.
-        // while `orphans` is not empty:
-        //   1. delete all edges leaving nodes in `orphans`.
-        //   2. For all nodes that just had an incoming edge deleted, if they have no remaining inbound
-        //        edges, add them to `orphans`.
-        // If there are no remaining edges, then the graph is acyclic.
+}
 
-        let mut orphans = self.orphans.clone();
-        // maps (child -> {parents})
-        let mut incoming_edgemap = self.rev_edges.clone();
-        while !orphans.is_empty() {
-            let mut new_orphans = HashSet::new();
-            for parent in orphans.drain() {
-                // if the node has outgoing edges, iter them and remove the
-                // symmetric incoming edges.
-                if let Some(children) = self.fwd_edges.get(&parent) {
-                    for outgoing_edge in children.iter() {
-                        // delete the child -> parent relation
-                        // note: unwrap = OK, else the incoming_edgemap was created incorrectly.
-                        let mut parents = incoming_edgemap.get_mut(&outgoing_edge.to).unwrap();
-                        parents.remove(&parent);
-                        if parents.is_empty() {
-                            // this node is now an orphan
-                            new_orphans.insert(outgoing_edge.to.clone());
-                        }
-                    }
-                }
-            }
-            orphans = new_orphans;
-        }
-
-        // if all nodes have no parents, we have no cycles.
-        if incoming_edgemap.iter().all(|(_child, parent_edges)| { parent_edges.is_empty() }) {
-            Ok(())
-        } else {
-            // cycle detected.
-            Err(())
+impl<N : Eq + Hash, E : Eq + Hash> DagNode<N, E> {
+    fn new(value: N) -> Self {
+        DagNode {
+            value: value,
+            children: HashSet::new(),
         }
     }
-    /*fn num_edges(&self) -> usize {
-        // sum the number of edges leaving each node:
-        self.edges.iter().fold(0, |sum, (_key, val)| {
-            sum + val.len()
+    /*fn iter_depth_first<'a>(&'a self) -> impl Iterator<Item=&'a DagEdge<N, E>> + 'a {
+        // for each child, yield it and then iter its children
+        self.children.iter().flat_map(|ref edge| {
+            edge.to.node.borrow().iter_depth_first()
+        })
+    }*/
+    /*fn iter_depth_first<'a>(&'a self) -> impl iterator<item=&'a dagnodehandle<n, e>> + 'a {
+        // for each child, yield it and then iter its children
+        self.children.iter().flat_map(|ref child| {
+            let child_to_node = child.to.node.borrow();
+            some(&child.to).into_iter()
+            .chain(child_to_node.iter_depth_first())
         })
     }*/
 }
 
-impl<T> Clone for DagNodeHandle<T> {
+impl<N, E> Clone for DagNodeHandle<N, E> {
     fn clone(&self) -> Self {
-        DagNodeHandle{ value: self.value.clone() }
+        DagNodeHandle{ node: self.node.clone() }
     }
 }
 
-impl<T> Hash for DagNodeHandle<T> {
+impl<N, E> Hash for DagNodeHandle<N, E> {
     fn hash<H>(&self, state: &mut H)  where H: Hasher {
-        (&*self.value as *const T).hash(state)
+        (&*self.node.borrow() as *const DagNode<N, E>).hash(state)
     }
 }
-impl<T> PartialEq for DagNodeHandle<T> {
+impl<N, E> PartialEq for DagNodeHandle<N, E> {
     fn eq(&self, other: &Self) -> bool {
-        &*self.value as *const T == &*other.value as *const T
+        &*self.node.borrow() as *const DagNode<N, E> == &*other.node.borrow() as *const DagNode<N, E>
     }
 }
-impl<T> Eq for DagNodeHandle<T> {}
+impl<N, E> Eq for DagNodeHandle<N, E> {}
 
-impl<T> DagNodeHandle<T> {
-    pub fn new(value: T) -> Self {
-        DagNodeHandle{ value: Rc::new(value)}
+impl<N, E> DagNodeHandle<N, E> {
+    fn new(node: DagNode<N, E>) -> Self {
+        DagNodeHandle{ node: Rc::new(RefCell::new(node))}
     }
 }
 
+impl<N, E> DagEdge<N, E> {
+    fn new(to: DagNodeHandle<N, E>, weight: E) -> Self {
+        DagEdge{ to: to, weight: weight }
+    }
+}
 
 impl<N, E : Hash> Hash for DagEdge<N, E> {
     fn hash<H>(&self, state: &mut H)  where H: Hasher {
         self.to.hash(state);
-        self.user_data.hash(state)
+        self.weight.hash(state)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,10 @@ struct DagNode<NodeData, EdgeData> {
     children: HashSet<DagEdge<NodeData, EdgeData>>,
 }
 
+struct DagIter<N, E> {
+    stack: Vec<HashSet<DagEdge<N, E>>::Iter>,
+}
+
 // TODO: use a small-size optimized Set, e.g. smallset
 // https://github.com/cfallin/rust-smallset/blob/master/src/lib.rs
 


### PR DESCRIPTION
This simplifies a lot of the cycle detection code, etc. More importantly, it allows automatic garbage collection of full sub-graphs only if they aren't reachable from Root and aren't reachable from any user-held NodeHandles.
